### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/HavokDevRel/ee37677d-bce0-4483-8683-acc6cf03cff2/dba58352-b71c-470d-8a30-a07f46c1c487/_apis/work/boardbadge/8061dd07-ae73-426d-9655-385d4aa3ce02)](https://dev.azure.com/HavokDevRel/ee37677d-bce0-4483-8683-acc6cf03cff2/_boards/board/t/dba58352-b71c-470d-8a30-a07f46c1c487/Microsoft.RequirementCategory)
 <p align="center">
 <img src="specification/figures/gltf.png" />
 </p>


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/HavokDevRel/ee37677d-bce0-4483-8683-acc6cf03cff2/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.